### PR TITLE
searchbar component developed

### DIFF
--- a/internify/src/components/molecules/SearchBar.js
+++ b/internify/src/components/molecules/SearchBar.js
@@ -1,0 +1,31 @@
+import React from "react";
+import Grid from '@material-ui/core/Grid';
+import TextField from '@material-ui/core/TextField';
+import './styles/SearchBar.css';
+import SearchIcon from '@material-ui/icons/Search';
+import InputAdornment from '@material-ui/core/InputAdornment';
+
+
+const SearchBar = () => {
+
+    return (
+        <Grid conatiner xs = {4} sm = {4} md = {4} className="searchbar_container">
+            <form className="searchbar_form">
+                <TextField className="searchbar_field" 
+                placeholder="Search for tags..." 
+                variant="outlined" 
+                size="small"
+                InputProps={{
+                    endAdornment: (
+                        <InputAdornment position="end">
+                            <SearchIcon/>
+                        </InputAdornment>
+                    ),
+                }}
+                style={{width: '100%'}}/>
+            </form>
+        </Grid>
+    )
+}
+
+export default SearchBar;

--- a/internify/src/components/molecules/styles/SearchBar.css
+++ b/internify/src/components/molecules/styles/SearchBar.css
@@ -1,0 +1,10 @@
+
+.searchbar_container {
+    padding-top: 30px;
+    padding-left: 30px;
+    padding-bottom: 50px;
+}
+
+.searchbar_form fieldset{
+    border-radius: 15px;
+}


### PR DESCRIPTION
#### User Story
user-story 11G - "search bar" , from epic: reusable components

#### Changes made
Using Material UI, created the reusable component "search bar" - this is located in the Molecule folder

#### Does your new code introduce new warnings on dev console?
No

#### Test Steps
For testing/ visualization purposes, add SearchBar component to an already created page, and run. 
<img width="667" alt="Screen Shot 2021-06-21 at 3 35 23 PM" src="https://user-images.githubusercontent.com/65432928/122836648-7dfc7300-d2a7-11eb-9c91-6bf4f31a0250.png">

