### PR TITLE
[IN-24] Floating Add Button

### DIFF
--- a/internify/src/assets/atoms/plus-btn-icon.svg
+++ b/internify/src/assets/atoms/plus-btn-icon.svg
@@ -1,0 +1,5 @@
+<svg width="70" height="70" viewBox="0 0 70 70" fill="none"
+    xmlns="http://www.w3.org/2000/svg">
+    <circle cx="35" cy="35" r="35" fill="#E61A4D"/>
+    <path d="M34.9997 20.5884L34.9997 49.4119M49.4114 35.0001L20.5879 35.0001" stroke="white" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/internify/src/components/atoms/Icon.js
+++ b/internify/src/components/atoms/Icon.js
@@ -1,5 +1,6 @@
-import { AddCircle, Grade } from "@material-ui/icons";
+import { Grade } from "@material-ui/icons";
 import { withStyles } from "@material-ui/core/styles";
+import { ReactComponent as AddCircle } from "../../assets/atoms/plus-btn-icon.svg";
 
 export const StarPlain = withStyles(() => ({
   root: {
@@ -31,18 +32,8 @@ export const StarColoured = withStyles(() => ({
   },
 }))(Grade);
 
-export const Add = withStyles(() => ({
-  root: {
-    cursor: "pointer",
-    color: "#FF1F57",
-    borderRadius: "50px",
-    boxShadow: "0px 4px 10px rgba(0, 0, 0, 0.05)",
-    "&:hover": {
-      borderRadius: "50px",
-      boxShadow: "0px 4px 10px rgba(0, 0, 0, 0.3)",
-    },
-    "&:active": {
-      opacity: 0.8,
-    },
-  },
-}))(AddCircle);
+export const Add = () => {
+  return (
+    <AddCircle className="add_circle_button"/>
+  )
+};

--- a/internify/src/components/atoms/Icon.js
+++ b/internify/src/components/atoms/Icon.js
@@ -34,9 +34,9 @@ export const StarColoured = withStyles(() => ({
 export const Add = withStyles(() => ({
   root: {
     cursor: "pointer",
-    color: "#E61A4D",
+    color: "#FF1F57",
     borderRadius: "50px",
-    boxShadow: "0px 4px 10px rgba(0, 0, 0, 0.1)",
+    boxShadow: "0px 4px 10px rgba(0, 0, 0, 0.05)",
     "&:hover": {
       borderRadius: "50px",
       boxShadow: "0px 4px 10px rgba(0, 0, 0, 0.3)",

--- a/internify/src/components/molecules/CreateJobButton.js
+++ b/internify/src/components/molecules/CreateJobButton.js
@@ -3,11 +3,11 @@ import { Add } from "../atoms/Icon";
 import "./styles/CreateJobButton.css";
 
 const CreateJobButton = () => {
-    return (
-        <Link className="create_job_button" to="/create">
-            <Add style={{ fontSize: 70 }}/>
-        </Link>
-    );
-}
+  return (
+    <Link className="create_job_button" to="/create">
+      <Add style={{ fontSize: 70 }} />
+    </Link>
+  );
+};
 
 export default CreateJobButton;

--- a/internify/src/components/molecules/CreateJobButton.js
+++ b/internify/src/components/molecules/CreateJobButton.js
@@ -1,0 +1,13 @@
+import { Link } from "react-router-dom";
+import { Add } from "../atoms/Icon";
+import "./styles/CreateJobButton.css";
+
+const CreateJobButton = () => {
+    return (
+        <Link className="create_job_button" to="/create">
+            <Add style={{ fontSize: 70 }}/>
+        </Link>
+    );
+}
+
+export default CreateJobButton;

--- a/internify/src/components/molecules/index.js
+++ b/internify/src/components/molecules/index.js
@@ -8,8 +8,10 @@ import TechStack from "./TechStack";
 import InputFormContactDetails from "./InputFormContactDetails";
 import JobPosting from "./JobPosting";
 import EditModal from "./EditModal";
+import CreateJobButton from "./CreateJobButton";
 
 export {
+  CreateJobButton,
   EditModal,
   PositionSubHeader,
   InputFormJobHeader,

--- a/internify/src/components/molecules/styles/CreateJobButton.css
+++ b/internify/src/components/molecules/styles/CreateJobButton.css
@@ -1,0 +1,6 @@
+.create_job_button {
+    position: absolute;
+    bottom: 5%;
+    right: 5%;
+    background-color: #FFFFFF;
+}

--- a/internify/src/components/molecules/styles/CreateJobButton.css
+++ b/internify/src/components/molecules/styles/CreateJobButton.css
@@ -11,5 +11,5 @@
   box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.3);
 }
 .create_job_button:active {
-    opacity: 0.8;
+  opacity: 0.8;
 }

--- a/internify/src/components/molecules/styles/CreateJobButton.css
+++ b/internify/src/components/molecules/styles/CreateJobButton.css
@@ -1,6 +1,15 @@
 .create_job_button {
-    position: absolute;
-    bottom: 5%;
-    right: 5%;
-    background-color: #FFFFFF;
+  position: absolute;
+  bottom: 5%;
+  right: 5%;
+  border-radius: 50px;
+  height: 70px;
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.2);
+}
+
+.create_job_button:hover {
+  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.3);
+}
+.create_job_button:active {
+    opacity: 0.8;
 }

--- a/internify/src/components/pages/Profile.js
+++ b/internify/src/components/pages/Profile.js
@@ -1,8 +1,7 @@
 import "./styles/Profile.css";
 import { Grid } from "@material-ui/core";
 import { React, useState } from "react";
-import { EditModal } from "../molecules/index";
-import { TableBasic } from "../molecules/Table";
+import { EditModal, TableBasic, CreateJobButton } from "../molecules/index";
 import angela from "../../assets/Profile/angela_brown.png";
 import { ButtonOutlined } from "../atoms/Button";
 import { ChipBasic } from "../atoms/Chips";
@@ -245,6 +244,7 @@ const Profile = () => {
         </Grid>
       </Grid>
       <EditModal toggle={toggle} setToggle={setToggle} />
+      <CreateJobButton/>
     </Grid>
   );
 };


### PR DESCRIPTION
#### User Story
[[IN-24]](https://chaosneutral.atlassian.net/jira/software/projects/IN/boards/1?selectedIssue=IN-24)

#### Changes made
- The original Material UI Icon `AddCircle` was too ugly so I exported an SVG from the Figma designs
- Added floating 'Add' button to the bottom right of the `Profile` page
- NOTE: This button should be added to all future pages:
  - `Home` page
  - `Browse` page
  - `View` page

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/37882255/125012160-92b66600-e01e-11eb-985d-ed2d9885067c.png">

#### Does your new code introduce new warnings on dev console?
No

#### Test Steps
1. Navigate to the `Profile` page
2. Click on the Add button, it should navigate you to the `Create` page
