### PR TITLE
[IN-96] Assign Score to JobPosting as number of matches

### DIFF
--- a/internify/backend/models/JobPostingData.js
+++ b/internify/backend/models/JobPostingData.js
@@ -6,6 +6,9 @@ const JobPostingSchema = new Schema({
   jobId: {
     type: String,
   },
+  score: {
+    type: Number,
+  },
   dateCreated: {
     type: Date,
   },

--- a/internify/backend/models/JobPostingData.js
+++ b/internify/backend/models/JobPostingData.js
@@ -6,7 +6,7 @@ const JobPostingSchema = new Schema({
   jobId: {
     type: String,
   },
-  score: {
+  matches: {
     type: Number,
   },
   dateCreated: {
@@ -15,7 +15,7 @@ const JobPostingSchema = new Schema({
   dateUpdated: {
     type: Date,
   },
-  score: {
+  matches: {
     type: Number,
   },
   header: {

--- a/internify/backend/routes/api/jobs.js
+++ b/internify/backend/routes/api/jobs.js
@@ -59,6 +59,7 @@ router.get("/:id", function (req, res, next) {
 router.post("/", function (req, res, next) {
   var newJob = new JobPostingData({
     jobId: req.body.jobId,
+    score: req.body.score,
     dateCreated: req.body.dateCreated,
     header: req.body.header,
     requirements: req.body.requirements,

--- a/internify/backend/routes/api/jobs.js
+++ b/internify/backend/routes/api/jobs.js
@@ -59,7 +59,7 @@ router.get("/:id", function (req, res, next) {
 router.post("/", function (req, res, next) {
   var newJob = new JobPostingData({
     jobId: req.body.jobId,
-    score: req.body.score,
+    matches: req.body.matches,
     dateCreated: req.body.dateCreated,
     header: req.body.header,
     requirements: req.body.requirements,

--- a/internify/src/App.js
+++ b/internify/src/App.js
@@ -50,9 +50,6 @@ function App() {
   });
 
   let routes;
-  if (isLoading) {
-    routes = <div>Loading</div>;
-  }
   if (user) {
     routes = (
       <Switch>

--- a/internify/src/components/molecules/JobPosting.js
+++ b/internify/src/components/molecules/JobPosting.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 import { ButtonFilled } from "../atoms/index";
 import { AddCircleOutline } from "@material-ui/icons";
@@ -30,6 +31,8 @@ const JobPosting = (props) => {
     details.pay,
     details.candidates,
   ];
+  
+  data.score = useSelector((state) => state.matches.page3Object?.page3Students?.length);
 
   function sendJob() {
     props.actions.addJob({ ...data, dateCreated: Date.now() });

--- a/internify/src/components/molecules/JobPosting.js
+++ b/internify/src/components/molecules/JobPosting.js
@@ -154,7 +154,7 @@ const JobPosting = (props) => {
       </ul>
 
       <div className="job_posting_submit">
-        <Link to={`/view/${jobId}`}>
+        <Link to={`/profile`}>
           <ButtonFilled
             onClick={() => sendJob()}
             startIcon={<AddCircleOutline />}

--- a/internify/src/components/molecules/JobPosting.js
+++ b/internify/src/components/molecules/JobPosting.js
@@ -32,7 +32,7 @@ const JobPosting = (props) => {
     details.candidates,
   ];
   
-  data.score = useSelector((state) => state.matches.page3Object?.page3Students?.length);
+  data.matches = useSelector((state) => state.matches.page3Object?.page3Students?.length);
 
   function sendJob() {
     props.actions.addJob({ ...data, dateCreated: Date.now() });

--- a/internify/src/components/molecules/RegisteredKeys.js
+++ b/internify/src/components/molecules/RegisteredKeys.js
@@ -1,33 +1,27 @@
-import React from 'react';
+import React from "react";
 import { ChipBasic } from "../atoms/index";
 import { connect } from "react-redux";
 import { v4 as uuidv4 } from "uuid";
 
 const RegisteredKeys = (props) => {
-    const registeredKeys = props.jobs.registeredKeys;
+  const registeredKeys = props.jobs.registeredKeys;
 
-    return (
-          <div className="registed_keys_container" style={{display: "flexbox"}}>
-          {Object.keys(registeredKeys).map(key => {
-              const current = registeredKeys[key];
-              if(Array.isArray(current)){
-                const result = current.map(ele => {
-                  return (
-                   <ChipBasic label={ele} key={uuidv4()}/>
-                  )
-                });
-                return result;
-              } else {
-                return (
-                  <ChipBasic label={current} key={uuidv4()}/>
-                );
-              }
-          })}
-          </div>
-    );
-
-}
-
+  return (
+    <div className="registed_keys_container" style={{ display: "flexbox" }}>
+      {Object.keys(registeredKeys).map((key) => {
+        const current = registeredKeys[key];
+        if (Array.isArray(current)) {
+          const result = current.map((ele) => {
+            return <ChipBasic label={ele} key={uuidv4()} />;
+          });
+          return result;
+        } else {
+          return <ChipBasic label={current} key={uuidv4()} />;
+        }
+      })}
+    </div>
+  );
+};
 
 function mapStateToProps(state) {
   return {
@@ -36,4 +30,3 @@ function mapStateToProps(state) {
 }
 
 export default connect(mapStateToProps)(RegisteredKeys);
-

--- a/internify/src/components/molecules/Table.js
+++ b/internify/src/components/molecules/Table.js
@@ -19,12 +19,12 @@ const useStyles = makeStyles({
   },
 });
 
-function createBasicData(jobId, title, dateCreated, score) {
-  return { jobId, title, dateCreated, score };
+function createBasicData(jobId, title, dateCreated,  matches) {
+  return { jobId, title, dateCreated, matches };
 }
 
-function createData(isStarred, jobId, title, dateCreated, score) {
-  return { isStarred, jobId, title, dateCreated, score };
+function createData(isStarred, jobId, title, dateCreated, matches) {
+  return { isStarred, jobId, title, dateCreated, matches };
 }
 
 export const TableBasic = (props) => {
@@ -34,7 +34,7 @@ export const TableBasic = (props) => {
       x.jobId,
       x.header?.title,
       x.dateCreated ? new Date(x.dateCreated) : null,
-      x.score ? x.score : null
+      x.matches ? x.matches : null
     );
   });
 
@@ -44,7 +44,7 @@ export const TableBasic = (props) => {
         <TableRow>
           <TableCell align="left">Posting&nbsp;title</TableCell>
           <TableCell align="left">Date&nbsp;created</TableCell>
-          <TableCell align="left">Score</TableCell>
+          <TableCell align="left">Matches</TableCell>
         </TableRow>
       </TableHead>
       <TableBody>
@@ -69,7 +69,7 @@ export const TableBasic = (props) => {
                 : null}
             </TableCell>
             <TableCell className={classes.row} align="left">
-              {row.score}
+              {row.matches}
             </TableCell>
           </TableRow>
         ))}
@@ -81,7 +81,7 @@ export const TableBasic = (props) => {
 export const TableStar = (props) => {
   const classes = useStyles();
   const rows = props.data?.map((x) => {
-    return createData(x.isStarred, x.title, x.dateCreated, x.score);
+    return createData(x.isStarred, x.title, x.dateCreated, x.matches);
   });
   console.log(rows);
 
@@ -92,7 +92,7 @@ export const TableStar = (props) => {
           <TableCell align="left" />
           <TableCell align="left">Posting&nbsp;title</TableCell>
           <TableCell align="left">Date&nbsp;created</TableCell>
-          <TableCell align="left">Score</TableCell>
+          <TableCell align="left">Matches</TableCell>
         </TableRow>
       </TableHead>
       <TableBody>
@@ -108,7 +108,7 @@ export const TableStar = (props) => {
               {row.dateCreated}
             </TableCell>
             <TableCell className={classes.row} align="left">
-              {row.score}
+              {row.matches}
             </TableCell>
           </TableRow>
         ))}

--- a/internify/src/components/organisms/Feedback.js
+++ b/internify/src/components/organisms/Feedback.js
@@ -19,14 +19,14 @@ const Feedback = ({ page }) => {
   if (page === 1) {
     return (
       <div className="feedback_outer">
-        <h2> {allStudents.length} total students </h2>
+        <h4>{allStudents.length} total students</h4>
       </div>
     );
   } else if (page === 2) {
     const msg = `${pageObjects.page1Object.page1Students.length} total matches`;
     return (
       <div className="feedback_outer">
-        <h2> {allStudents.length} total students </h2>
+        <h4> {allStudents.length} total students </h4>
         <SeekingStudents data={pageObjects.page1Object} display={display} />
         {display ? (
           <ChipEye
@@ -63,7 +63,7 @@ const Feedback = ({ page }) => {
     const msg = `${pageObjects.page2Object.page2Students.length} total matches`;
     return (
       <div className="feedback_outer">
-        <h2> {allStudents.length} total students </h2>
+        <h4> {allStudents.length} total students </h4>
         <SeekingStudents data={pageObjects.page1Object} display={display} />
         <TechMatchStudents data={pageObjects.page2Object} display={display} />
         {display ? (
@@ -101,7 +101,7 @@ const Feedback = ({ page }) => {
     const msg = `${pageObjects.page3Object.page3Students.length} total matches`;
     return (
       <div className="feedback_outer">
-        <h2> {allStudents.length} total students </h2>
+        <h4>{allStudents.length} total students</h4>
         <SeekingStudents data={pageObjects.page1Object} display={display} />
         <TechMatchStudents data={pageObjects.page2Object} display={display} />
         <FinalReqStudents data={pageObjects.page3Object} display={display} />

--- a/internify/src/components/pages/Create.js
+++ b/internify/src/components/pages/Create.js
@@ -297,7 +297,7 @@ function Create(props) {
     } else {
       setError(true);
     }
-  }
+  };
 
   return (
     <div className={classes.root}>
@@ -378,10 +378,14 @@ function Create(props) {
           )}
         </Grid>
         <Grid item xs={3}>
-          <h2 className="keys_title">Registered Keys</h2>
-          <div className="reg_keys_container">
-            <RegisteredKeys />
-          </div>
+          {Object.keys(props.jobs.registeredKeys).length > 0 ? (
+            <>
+              <h2 className="keys_title">Registered Keys</h2>
+              <div className="reg_keys_container">
+                <RegisteredKeys />
+              </div>
+            </>
+          ) : null}
           <h2 className="keys_title">Summary</h2>
           <div className="reg_keys_container">
             <Feedback page={currentStep} />

--- a/internify/src/components/pages/Create.js
+++ b/internify/src/components/pages/Create.js
@@ -83,7 +83,7 @@ function Create(props) {
     jobId: uuidv4(),
     dateCreated: "",
     dateUpdated: "",
-    score: 0,
+    matches: 0,
     header: {
       title: "",
       company: "",

--- a/internify/src/components/pages/Create.js
+++ b/internify/src/components/pages/Create.js
@@ -18,7 +18,11 @@ import { mockJobDetailData } from "../../models/mockData";
 import { connect } from "react-redux";
 import { bindActionCreators } from "redux";
 import { getStudents } from "../../store/actions/studentActions";
-import { addJobsData, resetKey, updateRegKeys } from "../../store/actions/jobPostActions";
+import {
+  addJobsData,
+  resetKey,
+  updateRegKeys,
+} from "../../store/actions/jobPostActions";
 import { processMatches } from "../../store/actions/matchesActions";
 import firebase from "firebase/app";
 import "firebase/auth";
@@ -66,8 +70,8 @@ const chipsList = [
   "pay",
   "candidates",
   "academicReq",
-  "positionType"
-]
+  "positionType",
+];
 
 function Create(props) {
   const classes = useStyles();
@@ -220,9 +224,9 @@ function Create(props) {
     return false;
   }
 
-  function updateKeysList(event, key, label){
-    if(chipsList.includes(key)){
-      if(registeredKeys.hasOwnProperty(key)){
+  function updateKeysList(event, key, label) {
+    if (chipsList.includes(key)) {
+      if (registeredKeys.hasOwnProperty(key)) {
         if (event.target.checked && !registeredKeys[key].includes(label)) {
           props.actions.updateRegKeys(key, [...registeredKeys[key], label]);
         } else {
@@ -239,8 +243,8 @@ function Create(props) {
     }
   }
 
-  function updateKeysText(v, data){
-    if(chipsList.includes(v)){
+  function updateKeysText(v, data) {
+    if (chipsList.includes(v)) {
       props.actions.updateRegKeys(v, data[v]);
     }
   }
@@ -249,7 +253,7 @@ function Create(props) {
     props.actions.getStudents();
     return () => {
       props.actions.resetKey();
-    }
+    };
   }, [props.actions]);
 
   function updateStore() {
@@ -373,14 +377,14 @@ function Create(props) {
             </div>
           )}
         </Grid>
-        <Grid item xs={3} >
+        <Grid item xs={3}>
           <h2 className="keys_title">Registered Keys</h2>
-          <div className="reg_keys_container"> 
-          <RegisteredKeys />
+          <div className="reg_keys_container">
+            <RegisteredKeys />
           </div>
           <h2 className="keys_title">Summary</h2>
           <div className="reg_keys_container">
-          <Feedback page={currentStep} />
+            <Feedback page={currentStep} />
           </div>
         </Grid>
       </Grid>
@@ -403,7 +407,7 @@ function matchDispatchToProps(dispatch) {
         processMatches: processMatches,
         getStudents: getStudents,
         updateRegKeys: updateRegKeys,
-        resetKey: resetKey
+        resetKey: resetKey,
       },
       dispatch
     ),

--- a/internify/src/components/pages/Profile.js
+++ b/internify/src/components/pages/Profile.js
@@ -11,8 +11,8 @@ import {
   PhoneAndroidOutlined,
   Star,
   CheckCircleOutline,
+  AccountCircle
 } from "@material-ui/icons";
-import { AccountCircle } from "@material-ui/icons";
 import "./styles/Profile.css";
 
 const Profile = (props) => {

--- a/internify/src/components/pages/View.js
+++ b/internify/src/components/pages/View.js
@@ -78,8 +78,8 @@ const View = () => {
                       new Date(job.dateCreated).getFullYear()
                     : null}
                 </li>
-                <li key={"job-posting-score"}>
-                  Score: <b>{job.score}</b>
+                <li key={"job-posting-matches"}>
+                  Matches: <b>{job.matches}</b>
                 </li>
               </ul>
             </div>

--- a/internify/src/components/pages/View.js
+++ b/internify/src/components/pages/View.js
@@ -79,7 +79,7 @@ const View = () => {
                     : null}
                 </li>
                 <li key={"job-posting-score"}>
-                  <b>Score: </b>80%
+                  Score: <b>{job.score}</b>
                 </li>
               </ul>
             </div>

--- a/internify/src/components/pages/styles/Create.css
+++ b/internify/src/components/pages/styles/Create.css
@@ -19,5 +19,5 @@
 
 .keys_title{
     margin-left: -15%; 
-    margin-bottom: 0.25rem;
+    margin-bottom: 1rem;
 }

--- a/internify/src/store/actions/jobPostActions.js
+++ b/internify/src/store/actions/jobPostActions.js
@@ -12,12 +12,6 @@ export const getJob = (data) => async() => {
   return res;
 };
 
-export const getBulkJobs = (data) => (dispatch) => {
-  axios.get(`/api/jobs/bulk`).then((res) => {
-    //TODO: Calling the action only returns the promise
-  });
-};
-
 export const getJobs = (user) => (dispatch) => {
   const jobIds = user.jobPostings;
       axios


### PR DESCRIPTION
#### User Story
[[IN-96] Assign Score to JobPosting as number of matches ](https://chaosneutral.atlassian.net/browse/IN-96)

#### Changes made
- Updated the job posting schema to include a new field `matches`
- Renamed "Score" to "Matches" in the table, View page, and job posting schema to better match the definition of the number
  - I found that with "score" it doesn't iterate well with that the number conveys. For example, with 1000 students, and 608 matches, your 'score' would be 608, but it doesn't translate well on whether or not you got a good score or not.
- *PLUS*: Added conditional rendering for `RegisteredKeys` to only display when there are keys registered
  - I did this because in the initial state of the Create page, it shows too much info on the right column. From a UX perspective, it may confuse the users on what info that column is trying to convey.

![image](https://user-images.githubusercontent.com/37882255/127698380-d36ff9e6-b067-427c-9298-1bf324dd990c.png)

#### Does your new code introduce new warnings on dev console?
Should not.

#### Test Steps
1. Create a job posting
2. Upon creating a job posting, you will be redirected to the View page. You should be able to see the number of matches displayed beside the date creation: 
![image](https://user-images.githubusercontent.com/37882255/127698794-e57cc7a8-f60b-4537-8b32-46662ddbce94.png)
3. Go back to the Profile page and you should see the number of matches in the end column of the table associated with the job posting 
