### PR TITLE
Feat/in104 nonauth view

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -62,7 +62,7 @@ function App() {
         <Route path="/selection">
           <AuthNavbar />
           <Prefill />
-          <Footer absolute={true}/>
+          <Footer absolute={true} />
         </Route>
         <Route path="/create">
           <AuthNavbar />
@@ -71,7 +71,7 @@ function App() {
         </Route>
         <Route path="/view/:slug">
           <AuthNavbar />
-          <View status={"authenticated"}/>
+          <View status={"authenticated"} />
           <Footer />
         </Route>
         <Redirect to="/profile" />
@@ -83,12 +83,12 @@ function App() {
         <Route path="/login">
           <Login />
         </Route>
+        <Route path="/view/:slug">
+          <View status={"nonauthenticated"} />
+          <Footer />
+        </Route>
         <Route path="/">
           <Landing />
-        </Route>
-        <Route path="/view/:slug">
-          <View status={"nonauthenticated"}/>
-          <Footer />
         </Route>
         <Redirect to="/" />
       </Switch>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -71,7 +71,7 @@ function App() {
         </Route>
         <Route path="/view/:slug">
           <AuthNavbar />
-          <View />
+          <View status={"authenticated"}/>
           <Footer />
         </Route>
         <Redirect to="/profile" />
@@ -85,6 +85,10 @@ function App() {
         </Route>
         <Route path="/">
           <Landing />
+        </Route>
+        <Route path="/view/:slug">
+          <View status={"nonauthenticated"}/>
+          <Footer />
         </Route>
         <Redirect to="/" />
       </Switch>

--- a/client/src/components/pages/View.js
+++ b/client/src/components/pages/View.js
@@ -9,7 +9,7 @@ import LinkIcon from "@material-ui/icons/Link";
 import axios from "axios";
 import "./styles/View.css";
 
-const View = () => {
+const View = (props) => {
   let { slug } = useParams();
   const [job, setJob] = useState(null);
   const [copySuccess, setCopySuccess] = useState(false);
@@ -84,9 +84,11 @@ const View = () => {
               </ul>
             </div>
             <div className="view_page_buttons_list">
-              <ButtonOutlined styles={{}} startIcon={<CreateOutlined />}>
-                Edit
-              </ButtonOutlined>
+              {props.status === "authenticated" && (
+                <ButtonOutlined styles={{}} startIcon={<CreateOutlined />}>
+                  Edit
+                </ButtonOutlined>
+              )}
               {"    "}
               <ButtonOutlined
                 startIcon={<LinkIcon />}


### PR DESCRIPTION
#### User Story
**IN-104 Put `View` page in both authenticated and non-authenticated routes**
https://chaosneutral.atlassian.net/jira/software/projects/IN/boards/1/backlog?selectedIssue=IN-104

#### Changes made
There is now a view page route that is for unauthenticated users.  Naturally, this route does not include an authenticated navbar, and, importantly, there is no "Edit" button on the view page (as we do not want random ppl being able to edit a job post). 

[There is one concern I have with the current nonauthenticated view setup; although it prevents nonauthenticated ppl from accessing the edit functionality of a job post, it will not prevent someone who is an authenticated user from editing another user's job post, assuming the latter sent the former the job link.

Would love to hear other's thoughts on this concern. I am currently attempting to find a time-efficient and elegant solution to this, hence why the PR is currently blocked.]

^ Note, Tommy's homepage story addresses this issue.  Once @tommytwm  is completed that story, this one will be opened again, and unblocked.



#### Does your new code introduce new warnings on dev console?
No

#### Test Steps
1. Run the site
2. Log in
3. View a job
4. Copy the job's link
5. log out
6. paste the job link in your browser
7. should be able to see the unauthenticated view page
