### PR TITLE
Feat/in104 nonauthorized view

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -78,7 +78,7 @@ function App() {
         </Route>
         <Route path="/view/:slug">
           <AuthNavbar />
-          <View user={user}/>
+          <View user={user} status={"authenticated"}/>
           <Footer />
         </Route>
         <Route path="/edit/:slug">
@@ -94,6 +94,10 @@ function App() {
       <Switch>
         <Route path="/login">
           <Login />
+        </Route>
+        <Route path="/view/:slug">
+          <View status={"nonauthenticated"} />
+          <Footer />
         </Route>
         <Route path="/">
           <Landing />

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -78,7 +78,7 @@ function App() {
         </Route>
         <Route path="/view/:slug">
           <AuthNavbar />
-          <View user={user} status={"authenticated"}/>
+          <View user={user} authenticated={true}/>
           <Footer />
         </Route>
         <Route path="/edit/:slug">
@@ -96,7 +96,7 @@ function App() {
           <Login />
         </Route>
         <Route path="/view/:slug">
-          <View status={"nonauthenticated"} />
+          <View authenticated={false}/>
           <Footer />
         </Route>
         <Route path="/">

--- a/client/src/components/pages/View.js
+++ b/client/src/components/pages/View.js
@@ -108,12 +108,14 @@ const View = (props) => {
             </div>
             <div className="view_page_buttons_list">
             <Link to={`/edit/${job.jobId}`}>
-            <ButtonOutlined 
-              style={{ marginRight: "0.5em", marginBottom: "0.5em" }} 
-              startIcon={<CreateOutlined />}
-              >
-                Edit
-              </ButtonOutlined>
+              {(props.authenticated) && job.author === user.uid && (
+                <ButtonOutlined 
+                style={{ marginRight: "0.5em", marginBottom: "0.5em" }} 
+                startIcon={<CreateOutlined />}
+                >
+                  Edit
+                </ButtonOutlined>
+              )}
             </Link>
               <ButtonOutlined
                 style={{ marginRight: "0.5em", marginBottom: "0.5em" }}
@@ -122,13 +124,15 @@ const View = (props) => {
               >
                 Copy Link
               </ButtonOutlined>
-              <ButtonOutlined
+              {(props.authenticated) && job.author === user.uid && (
+                <ButtonOutlined
                 style={{ marginRight: "0.5em", marginBottom: "0.5em" }}
                 startIcon={<HighlightOff />}
                 onClick={() => handleDelete()}
               >
                 Delete
               </ButtonOutlined>
+              )}
               {copySuccess && (
                 <Alert
                   variant="outlined"


### PR DESCRIPTION
User Story
IN-104 Put View page in both authenticated and non-authenticated routes
https://chaosneutral.atlassian.net/jira/software/projects/IN/boards/1/backlog?selectedIssue=IN-104

Changes made
There is now a view page route that is for unauthenticated users. Naturally, this route does not include an authenticated navbar, and, importantly, there is no "Edit" or "Delete" button on the view page (as we do not want random ppl being able to edit a job post).

Similarly, if a user is authenticated - but not the author of a job post - they will now be able to view a job posting but without Edit or Delete functionality available to them.  



Does your new code introduce new warnings on dev console?
No

Test Steps
Run the site
Log in
View a job
Copy the job's link
log out
paste the job link in your browser
should be able to see the unauthenticated view page (i.e. sans Edit or Delete buttons)
