### PR TITLE
Feat/in107 prefill select page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -11,6 +11,7 @@ import Footer from "./components/organisms/Footer";
 import View from "./components/pages/View";
 import Home from "./components/pages/Home";
 import Prefill from "./components/pages/Prefill";
+import Templates from "./components/pages/Templates";
 import "./App.css";
 import {
   BrowserRouter as Router,
@@ -70,6 +71,11 @@ function App() {
           <AuthNavbar />
           <Prefill />
           <Footer absolute={true}/>
+        </Route>
+        <Route path="/templates">
+          <AuthNavbar />
+          <Templates />
+          <Footer />
         </Route>
         <Route path="/create">
           <AuthNavbar />

--- a/client/src/components/molecules/TemplatePosting.js
+++ b/client/src/components/molecules/TemplatePosting.js
@@ -1,0 +1,94 @@
+import React from "react";
+import "./styles/TemplatePosting.css";
+
+const TemplatePosting = (props) => {
+  const data = props.data;
+  const header = data?.header
+    ? data.header
+    : {
+        title: "",
+        company: "",
+        location: "",
+        description: "",
+      };
+  const requirements = data?.requirements;
+  const details = data?.details;
+  const contact = data?.contact;
+
+  const jobPoints = [
+    ...header.position,
+    details.position,
+    details.pay,
+    details.candidates,
+  ];
+
+  const JobPosting = (props) => {
+    return (
+      <div className="template_posting_container">
+        <h3 className="template_posting_title">{header.title}</h3>
+
+        <h4 className="template_posting_subheader">Technical Requirements</h4>
+        <ul className="template_posting_list_2">
+          <li
+            key={"coding-language-requirement"}
+            style={{ marginBottom: "0.25em" }}
+          >
+            Experience with the following programming languages:
+          </li>
+          <ul className="template_posting_list_nested">
+            {requirements.languages.map((language) => {
+              return (
+                <li key={language}>
+                  <b>{language}</b>
+                </li>
+              );
+            })}
+          </ul>
+          <li key={"framework-requirement"}>
+            Experience with the following frameworks:
+          </li>
+          <ul className="template_posting_list_nested">
+            {requirements.frameworks.map((framework) => {
+              return (
+                <li key={framework}>
+                  <b>{framework}</b>
+                </li>
+              );
+            })}
+          </ul>
+          <li key={"tool-requirement"}>
+            Experience with the following work tools:
+          </li>
+          <ul className="template_posting_list_nested">
+            {requirements.tools.map((tool) => {
+              return (
+                <li key={tool}>
+                  <b>{tool}</b>
+                </li>
+              );
+            })}
+          </ul>
+          <li key={"concept-requirement"}>
+            General understanding and comprehension of:
+          </li>
+          <ul className="template_posting_list_nested">
+            {requirements.concepts.map((concept) => {
+              return (
+                <li key={concept}>
+                  <b>{concept}</b>
+                </li>
+              );
+            })}
+          </ul>
+        </ul>
+      </div>
+    );
+  };
+
+  return (
+      <JobPosting />
+  );
+};
+
+export default TemplatePosting;
+

--- a/client/src/components/molecules/TemplatePosting.js
+++ b/client/src/components/molecules/TemplatePosting.js
@@ -12,15 +12,6 @@ const TemplatePosting = (props) => {
         description: "",
       };
   const requirements = data?.requirements;
-  const details = data?.details;
-  const contact = data?.contact;
-
-  const jobPoints = [
-    ...header.position,
-    details.position,
-    details.pay,
-    details.candidates,
-  ];
 
   const JobPosting = (props) => {
     return (
@@ -85,10 +76,7 @@ const TemplatePosting = (props) => {
     );
   };
 
-  return (
-      <JobPosting />
-  );
+  return <JobPosting />;
 };
 
 export default TemplatePosting;
-

--- a/client/src/components/molecules/index.js
+++ b/client/src/components/molecules/index.js
@@ -10,6 +10,7 @@ import JobPosting from "./JobPosting";
 import EditModal from "./EditModal";
 import CreateJobButton from "./CreateJobButton";
 import ViewPosting from "./ViewPosting";
+import TemplatePosting from "./TemplatePosting";
 
 export {
   CreateJobButton,
@@ -25,4 +26,5 @@ export {
   TechStack,
   InputFormContactDetails,
   ViewPosting,
+  TemplatePosting,
 };

--- a/client/src/components/molecules/styles/TemplatePosting.css
+++ b/client/src/components/molecules/styles/TemplatePosting.css
@@ -1,0 +1,61 @@
+ 
+  
+  .template_posting_container {
+    border: 0.75px solid #000000;
+    padding: 2em 1.5em;
+    font-size: 16px;
+    margin-bottom: 7em;
+  }
+  
+  .template_posting_title {
+    margin-top: 0;
+    margin-bottom: 0.5em;
+    font-size: 1.5em;
+  }
+  .template_posting_subheader {
+    margin-top: 0;
+    margin-bottom: 0.5em;
+  }
+  
+  .template_posting_description {
+    margin-top: 2em;
+    margin-bottom: 2em;
+  }
+  
+  .view_posting_points {
+    margin-bottom: 0.5em;
+  }
+  
+  .template_posting_list {
+    display: inline-flex;
+    flex-wrap: wrap;
+    line-height: 1.5em;
+    margin: 0;
+    margin-bottom: 1em;
+  }
+  
+  .template_posting_list_2 {
+    line-height: 1.5em;
+    margin: 0;
+  }
+  .template_posting_list_nested {
+    line-height: 1.5em;
+    margin: 0;
+    padding-left: 1.5em;
+    margin-bottom: 0.5em;
+  }
+  
+  .template_posting_list li {
+    margin-right: 2em;
+  }
+  
+  .template_posting_contact_name {
+    margin-bottom: 1em;
+  }
+  
+  .template_posting_submit {
+    position: fixed;
+    bottom: 5vh;
+    left: 43vw;
+  }
+  

--- a/client/src/components/molecules/styles/TemplatePosting.css
+++ b/client/src/components/molecules/styles/TemplatePosting.css
@@ -8,7 +8,7 @@
 .template_posting_container:hover {
   cursor: pointer;
   box-shadow: 0 5px 10px rgb(0 0 0 0.2);
-  background-color: #e2e2e2;
+  background-color: #faf9f6;
   overflow: visible;
 }
 

--- a/client/src/components/molecules/styles/TemplatePosting.css
+++ b/client/src/components/molecules/styles/TemplatePosting.css
@@ -1,61 +1,65 @@
- 
-  
-  .template_posting_container {
-    border: 0.75px solid #000000;
-    padding: 2em 1.5em;
-    font-size: 16px;
-    margin-bottom: 7em;
-  }
-  
-  .template_posting_title {
-    margin-top: 0;
-    margin-bottom: 0.5em;
-    font-size: 1.5em;
-  }
-  .template_posting_subheader {
-    margin-top: 0;
-    margin-bottom: 0.5em;
-  }
-  
-  .template_posting_description {
-    margin-top: 2em;
-    margin-bottom: 2em;
-  }
-  
-  .view_posting_points {
-    margin-bottom: 0.5em;
-  }
-  
-  .template_posting_list {
-    display: inline-flex;
-    flex-wrap: wrap;
-    line-height: 1.5em;
-    margin: 0;
-    margin-bottom: 1em;
-  }
-  
-  .template_posting_list_2 {
-    line-height: 1.5em;
-    margin: 0;
-  }
-  .template_posting_list_nested {
-    line-height: 1.5em;
-    margin: 0;
-    padding-left: 1.5em;
-    margin-bottom: 0.5em;
-  }
-  
-  .template_posting_list li {
-    margin-right: 2em;
-  }
-  
-  .template_posting_contact_name {
-    margin-bottom: 1em;
-  }
-  
-  .template_posting_submit {
-    position: fixed;
-    bottom: 5vh;
-    left: 43vw;
-  }
-  
+.template_posting_container {
+  border: 0.75px solid #000000;
+  padding: 2em 1.5em;
+  font-size: 16px;
+  margin-bottom: 7em;
+}
+
+.template_posting_container:hover {
+  cursor: pointer;
+  box-shadow: 0 5px 10px rgb(0 0 0 0.2);
+  background-color: #e2e2e2;
+  overflow: visible;
+}
+
+.template_posting_title {
+  margin-top: 0;
+  margin-bottom: 0.5em;
+  font-size: 1.5em;
+}
+.template_posting_subheader {
+  margin-top: 0;
+  margin-bottom: 0.5em;
+}
+
+.template_posting_description {
+  margin-top: 2em;
+  margin-bottom: 2em;
+}
+
+.view_posting_points {
+  margin-bottom: 0.5em;
+}
+
+.template_posting_list {
+  display: inline-flex;
+  flex-wrap: wrap;
+  line-height: 1.5em;
+  margin: 0;
+  margin-bottom: 1em;
+}
+
+.template_posting_list_2 {
+  line-height: 1.5em;
+  margin: 0;
+}
+.template_posting_list_nested {
+  line-height: 1.5em;
+  margin: 0;
+  padding-left: 1.5em;
+  margin-bottom: 0.5em;
+}
+
+.template_posting_list li {
+  margin-right: 2em;
+}
+
+.template_posting_contact_name {
+  margin-bottom: 1em;
+}
+
+.template_posting_submit {
+  position: fixed;
+  bottom: 5vh;
+  left: 43vw;
+}

--- a/client/src/components/pages/Prefill.js
+++ b/client/src/components/pages/Prefill.js
@@ -50,7 +50,7 @@ function Prefill() {
         spacing={7}
         >
           <Grid item>
-          <Link to="/create" style={{ textDecoration: "none" }}>
+          <Link to="/templates" style={{ textDecoration: "none" }}>
           <ButtonFilled className={classes.prefill_btn_left}>Preview Prefills</ButtonFilled>
           </Link>
           </Grid>

--- a/client/src/components/pages/Templates.js
+++ b/client/src/components/pages/Templates.js
@@ -1,0 +1,63 @@
+import { React } from "react";
+import { Link } from "react-router-dom";
+import { Grid } from "@material-ui/core";
+import { ChevronLeft } from "@material-ui/icons";
+import { ButtonClear } from "../atoms";
+import { TemplatePosting } from "../molecules/index";
+import {
+  backEndStudent,
+  frontEndStudent,
+  dataScienceStudent,
+  fullStackStudent,
+} from "../../models/templateJobDataObjects";
+import "./styles/Templates.css";
+
+
+const Templates = () => {
+  return (
+    <Grid>
+      <Grid item xs={2}>
+        <Grid container justifyContent="flex-end">
+          <Link to="/selection">
+            <ButtonClear startIcon={<ChevronLeft />}>Back</ButtonClear>
+          </Link>
+        </Grid>
+      </Grid>
+      <Grid item xs={10}>
+        <div className="page_title">
+          <h1>Select Prefills</h1>
+          <h4 className="message">Select from 4 available templates</h4>
+        </div>
+      </Grid>
+      <Grid
+        container
+        style={{ paddingTop: "1em" }}
+        direction="row"
+        alignItems="flex-start"
+        justifyContent="flex-end"
+      >
+        <Grid item xs={10}>
+          <Grid container direction="row">
+            <div className="templates_container">
+              <div className="template" >
+                <TemplatePosting data={backEndStudent} hide={true}/>
+              </div>
+              <div className="template" >
+                <TemplatePosting data={frontEndStudent} hide={true}/>
+              </div>
+              <div className="template" >
+                <TemplatePosting data={dataScienceStudent} hide={true}/>
+              </div>
+              <div className="template">
+                <TemplatePosting data={fullStackStudent} hide={true}/>
+              </div>
+            </div>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default Templates;
+

--- a/client/src/components/pages/Templates.js
+++ b/client/src/components/pages/Templates.js
@@ -12,7 +12,6 @@ import {
 } from "../../models/templateJobDataObjects";
 import "./styles/Templates.css";
 
-
 const Templates = () => {
   return (
     <Grid>
@@ -39,17 +38,17 @@ const Templates = () => {
         <Grid item xs={10}>
           <Grid container direction="row">
             <div className="templates_container">
-              <div className="template" >
-                <TemplatePosting data={backEndStudent} hide={true}/>
-              </div>
-              <div className="template" >
-                <TemplatePosting data={frontEndStudent} hide={true}/>
-              </div>
-              <div className="template" >
-                <TemplatePosting data={dataScienceStudent} hide={true}/>
+              <div className="template">
+                <TemplatePosting data={backEndStudent} hide={true} />
               </div>
               <div className="template">
-                <TemplatePosting data={fullStackStudent} hide={true}/>
+                <TemplatePosting data={frontEndStudent} hide={true} />
+              </div>
+              <div className="template">
+                <TemplatePosting data={dataScienceStudent} hide={true} />
+              </div>
+              <div className="template">
+                <TemplatePosting data={fullStackStudent} hide={true} />
               </div>
             </div>
           </Grid>
@@ -60,4 +59,3 @@ const Templates = () => {
 };
 
 export default Templates;
-

--- a/client/src/components/pages/styles/Templates.css
+++ b/client/src/components/pages/styles/Templates.css
@@ -12,12 +12,11 @@
   margin-right: 5%;
 }
 
-
 .page_title {
   text-align: left;
   margin-left: 22%;
   padding-bottom: 2%;
-  margin-top: -4.2%;
+  margin-top: -4.5%;
 }
 
 .message {

--- a/client/src/components/pages/styles/Templates.css
+++ b/client/src/components/pages/styles/Templates.css
@@ -1,0 +1,33 @@
+.templates_container {
+    display: flex;
+    overflow-x: scroll;
+    overflow-y: scroll;
+    white-space: nowrap;
+    margin-right: 3%;
+  }
+  
+  
+  .template {
+    display: inline-block;
+    margin-left: 2%;
+    margin-right: 5%;
+  }
+  
+  .template:hover {
+    cursor: pointer;
+    box-shadow: 0 5px 10px rgb(0 0 0 0.2);
+  }
+  
+  .page_title {
+    text-align: left;
+    margin-left: 22%;
+    padding-bottom: 2%;
+    margin-top: -4.2%;
+  }
+  
+  .message {
+    font-weight: normal;
+  }
+  
+  
+  

--- a/client/src/components/pages/styles/Templates.css
+++ b/client/src/components/pages/styles/Templates.css
@@ -1,33 +1,25 @@
 .templates_container {
-    display: flex;
-    overflow-x: scroll;
-    overflow-y: scroll;
-    white-space: nowrap;
-    margin-right: 3%;
-  }
-  
-  
-  .template {
-    display: inline-block;
-    margin-left: 2%;
-    margin-right: 5%;
-  }
-  
-  .template:hover {
-    cursor: pointer;
-    box-shadow: 0 5px 10px rgb(0 0 0 0.2);
-  }
-  
-  .page_title {
-    text-align: left;
-    margin-left: 22%;
-    padding-bottom: 2%;
-    margin-top: -4.2%;
-  }
-  
-  .message {
-    font-weight: normal;
-  }
-  
-  
-  
+  display: flex;
+  overflow-x: scroll;
+  overflow-y: scroll;
+  white-space: nowrap;
+  margin-right: 3%;
+}
+
+.template {
+  display: inline-block;
+  margin-left: 2%;
+  margin-right: 5%;
+}
+
+
+.page_title {
+  text-align: left;
+  margin-left: 22%;
+  padding-bottom: 2%;
+  margin-top: -4.2%;
+}
+
+.message {
+  font-weight: normal;
+}


### PR DESCRIPTION
#### User Story
IN-107 (worked on by both @aleemer  and @ReneReid)

https://chaosneutral.atlassian.net/jira/software/projects/IN/boards/1/backlog?selectedIssue=IN-107

#### Changes made
Now the user can view 4 different job prefill templates:
(1) back end developer
(2) front end developer
(3) data scientist
(4) full stack developer

#### Does your new code introduce new warnings on dev console?
No

#### Test Steps
From your profile page, try to create a new job; once at the selection page, choose the prefill option; you will be directed to the template prefill page where you can see the different options

