### PR TITLE
[hof-fix] aligned the names of cs concepts minor diffs btw checkbox names and student fields

### DIFF
--- a/client/src/effects/filter.effects.js
+++ b/client/src/effects/filter.effects.js
@@ -3,6 +3,12 @@ function parseConcepts(concepts) {
   for (let i = 0; i < concepts.length; i++) {
     if (concepts[i] === "Object Oriented Programming") {
       parsedConcepts.push("Object-Oriented Programming");
+    } else if (concepts[i] === "Asynchronous Programming") {
+      parsedConcepts.push("Asynchronous programming");
+    } else if (concepts[i] === "RESTify Services") {
+      parsedConcepts.push("RESTify services");
+    } else if (concepts[i] === "Web APIs") {
+      parsedConcepts.push("web APIs");
     } else {
       parsedConcepts.push(concepts[i]);
     }

--- a/client/src/models/mockData.js
+++ b/client/src/models/mockData.js
@@ -77,14 +77,13 @@ const mockTechStackData = {
   csConcepts: [
     "Agile Development",
     "Algorithms",
-    "Asynchronous Programming",
+    "Asynchronous programming",
     "Data Structures",
-    "Design Principles & Patterns",
     "Functional Programming",
     "Object Oriented Programming",
-    "RESTify Services",
+    "RESTify services",
     "Recursion",
-    "Web APIs",
+    "web APIs",
   ],
 };
 

--- a/client/src/models/mockData.js
+++ b/client/src/models/mockData.js
@@ -53,7 +53,7 @@ const mockTechStackData = {
     "Python",
     "R",
     "SQL",
-    "TypeScript"
+    "TypeScript",
   ],
   frameworks: [
     "AWS",
@@ -68,22 +68,17 @@ const mockTechStackData = {
     "Ruby on Rails",
     "Unix",
   ],
-  workTools: [
-    "Azure",
-    "GitHub",
-    "Jira",
-    "Jupyter"
-  ],
+  workTools: ["Azure", "GitHub", "Jira", "Jupyter"],
   csConcepts: [
     "Agile Development",
     "Algorithms",
-    "Asynchronous programming",
+    "Asynchronous Programming",
     "Data Structures",
     "Functional Programming",
     "Object Oriented Programming",
-    "RESTify services",
+    "RESTify Services",
     "Recursion",
-    "web APIs",
+    "Web APIs",
   ],
 };
 
@@ -198,5 +193,5 @@ export {
   mockJobPosting,
   mockProfileData,
   chipsList,
-  currStep
+  currStep,
 };

--- a/client/src/models/mockData.js
+++ b/client/src/models/mockData.js
@@ -77,7 +77,6 @@ const mockTechStackData = {
     "Functional Programming",
     "Object Oriented Programming",
     "RESTify Services",
-    "Recursion",
     "Web APIs",
   ],
 };


### PR DESCRIPTION
#### User Story
NA - hotfix

#### Changes made
While testing different job creation routes, I realised there were a few slight mis-alignments in the check-box names of CS concepts vs how they appear in the student fields (e.g. "P" vs "p").  Changes therefore have been made to ensure perfect alignment. 

#### Does your new code introduce new warnings on dev console?
No.

#### Test Steps
Create a job, mindful of number of matches that appear when you only select CS concepts "Asynchronous programming" or "RESTify services" or "web APIs".  Should always get a non-0 number of matches now.
