### PR TITLE
Hotfix: Profile Page trigger Job Posting Table

### DIFF
--- a/client/src/components/pages/Profile.js
+++ b/client/src/components/pages/Profile.js
@@ -229,7 +229,7 @@ const Profile = (props) => {
           <Grid item>
             <h2>Postings</h2>
             <div className="profile_left_posting_table">
-              {props.jobs.currentListOfJobs ? (
+              {props.jobs.currentListOfJobs?.length > 0 ? (
                 <TableBasic className="posting_table" data={removeDuplicates(props.jobs.currentListOfJobs)} />
               ) : (
                 <div className="profile_no_posting_message">


### PR DESCRIPTION
#### User Story
N/A

#### Changes made
- The Profile page is supposed to trigger the table to display a message to tell users to add a job posting if they haven't any.

#### Does your new code introduce new warnings on dev console?
No

#### Test Steps
1. Log in to a user with no job postings
2. Go to the Profile page and you should see this message displayed in the right column:
<img width="1065" alt="image" src="https://user-images.githubusercontent.com/37882255/128944528-bc92a754-66a2-4ade-886b-1d38d7ba3311.png">

